### PR TITLE
Version 1.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>pt.uminho.haslab.pardinus</groupId>
 	<artifactId>pardinus</artifactId>
-	<version>1.2.0</version>
+	<version>1.2.2</version>
 	<packaging>jar</packaging>
 	<name>pardinus</name>
 	<profiles>

--- a/src/main/java/kodkod/engine/TemporalPardinusSolver.java
+++ b/src/main/java/kodkod/engine/TemporalPardinusSolver.java
@@ -563,6 +563,10 @@ implements KodkodSolver<PardinusBounds, ExtendedOptions>, TemporalSolver<Extende
 		private int iteration_stage = 0;
 
 		private Solution nextNonTrivialSolutionSAT(int state, int steps, Set<Relation> fix, Set<Relation> change) {
+			if (change.isEmpty()) {
+				translation = null;
+				return Solution.unsatisfiable(new Statistics(0, 0, 0, 0, 0), null);
+			}
 
 			boolean isSat = false;
 			long solveTime = 0;

--- a/src/main/java/kodkod/engine/fol2sat/SymmetryBreaker.java
+++ b/src/main/java/kodkod/engine/fol2sat/SymmetryBreaker.java
@@ -211,7 +211,7 @@ final class SymmetryBreaker {
 				int curIndex = indeces.next();
 				Iterator<Tuple> times = null;
 				if (bounds.relations().contains(TemporalTranslator.STATE))
-						bounds.lowerBound(TemporalTranslator.STATE).iterator();
+					times = bounds.lowerBound(TemporalTranslator.STATE).iterator();
 				Tuple time = null;
 				do {
 					for(Iterator<RelationParts> rIter = relParts.iterator(); rIter.hasNext() && original.size() < predLength;) {
@@ -239,7 +239,7 @@ final class SymmetryBreaker {
 								continue;
 							
 							boolean zzz = false;
-								if (times != null) {
+							if (times != null) {
 								TupleSet yyy = bounds.lowerBound(TemporalTranslator.STATE);
 								Tuple xxx = interpreter.universe().factory().tuple(interpreter.universe().factory().tuple(r.arity(), entry.index()).atom(r.arity()-1));
 								zzz = yyy.contains(xxx);	

--- a/src/main/java/kodkod/instance/Instance.java
+++ b/src/main/java/kodkod/instance/Instance.java
@@ -255,15 +255,18 @@ public class Instance implements Cloneable {
 		Set<Relation> relevants = formula.accept(new RelationCollector(new HashSet<>()));
 		// reify atoms not yet reified
 		for (int i = 0; i < universe().size(); i++) {
-			Expression r;
-			if (reif.keySet().contains(universe().atom(i)))
-				r = reif.get(universe().atom(i));
-			else {
-				r = Relation.atom(universe().atom(i).toString());
-				reif.put(universe().atom(i), r);
+			// integers do not need to be quantified
+			if (!universe().atom(i).toString().matches("-?\\d+")) {
+				Expression r;
+				if (reif.keySet().contains(universe().atom(i)))
+					r = reif.get(universe().atom(i));
+				else {
+					r = Relation.atom(universe().atom(i).toString());
+					reif.put(universe().atom(i), r);
+				}
+				if (r instanceof Relation && !bounds.relations.contains(r))
+					bounds.boundExactly((Relation) r, bounds.universe().factory().setOf(universe().atom(i)));
 			}
-			if (r instanceof Relation && !bounds.relations.contains(r))
-				bounds.boundExactly((Relation) r, bounds.universe().factory().setOf(universe().atom(i)));
 		}
 
 		// create an equality for every relation

--- a/src/main/java/kodkod/instance/Instance.java
+++ b/src/main/java/kodkod/instance/Instance.java
@@ -238,7 +238,7 @@ public class Instance implements Cloneable {
 	}
 	
 	public Formula formulate(Bounds bounds, Map<Object, Expression> reif, Formula formula, boolean someDisj) {
-		return formulate(bounds,reif,formula,someDisj);
+		return formulate(bounds,reif,formula,someDisj,false);
 	}
 	
 	/**

--- a/src/main/java/kodkod/instance/TemporalInstance.java
+++ b/src/main/java/kodkod/instance/TemporalInstance.java
@@ -236,20 +236,20 @@ public class TemporalInstance extends Instance {
 	 * Will change <bounds> if not all atoms of the universe are present at <reif>.
 	 * 
 	 * @assumes reif != null
-	 * @param bounds  the declaration of the relations
 	 * @param reif    the previously reified atoms
 	 * @param formula formula used to identify the relevant relations
+	 * @param bounds  the declaration of the relations
 	 * @throws NullPointerException reif = null
 	 * @return the formula representing <this>
 	 */
 	// [HASLab]
 	@Override
-	public Formula formulate(Bounds bounds, Map<Object, Expression> reif, Formula formula, boolean someDisj) {
+	public Formula formulate(Map<Object, Expression> reif, Formula formula, boolean someDisj, Bounds bounds) {
 		return formulate(bounds, reif, formula, -1, null, someDisj, true);
 	}
 
 	@Override
-	public Formula formulate(Bounds bounds, Map<Object, Expression> reif, Formula formula, boolean someDisj, boolean localUniv) {
+	public Formula formulate(Map<Object, Expression> reif, Formula formula, boolean someDisj, Bounds bounds, boolean localUniv) {
 		return formulate(bounds, reif, formula, -1, null, someDisj, localUniv);
 	}
 
@@ -332,9 +332,9 @@ public class TemporalInstance extends Instance {
 				j = Integer.max(start + (prefixLength() - 1) - loop, prefixLength() - 1);
 			if (j != null && j >= 0) {
 				// the state formulas, start from the end and accumulate afters
-				res = state(j--).formulate(bounds, reif, slcs.getValue(), someDisj, !localUniv);
+				res = state(j--).formulate(reif, slcs.getValue(), someDisj, bounds, !localUniv);
 				for (; j >= Integer.max(0, start); j--)
-					res = state(j).formulate(bounds, reif, slcs.getValue(), someDisj, !localUniv).and(res.after());
+					res = state(j).formulate(reif, slcs.getValue(), someDisj, bounds, !localUniv).and(res.after());
 				// after offset when start > 0
 				for (; j >= 0; j--)
 					res = res.after();
@@ -343,7 +343,7 @@ public class TemporalInstance extends Instance {
 
 			// the configuration formula, if start = -1
 			if (start < 0 && !slcs.getKey().equals(Formula.TRUE)) {
-				Formula sres = states.get(prefixLength() - 1).formulate(bounds, reif, slcs.getKey(), someDisj, false);
+				Formula sres = states.get(prefixLength() - 1).formulate(reif, slcs.getKey(), someDisj, bounds, false);
 				res = res.equals(Formula.TRUE) ? sres : sres.and(res);
 			}
 
@@ -352,14 +352,14 @@ public class TemporalInstance extends Instance {
 				// create the looping constraint
 				// after^loop always (Sloop => after^(end-loop) Sloop && Sloop+1 =>
 				// after^(end-loop) Sloop+1 && ...)
-				Formula rei = states.get(loop).formulate(bounds, reif, slcs.getValue(), someDisj, !localUniv);
+				Formula rei = states.get(loop).formulate(reif, slcs.getValue(), someDisj, bounds, !localUniv);
 				Formula rei2 = rei;
 				for (int i = loop; i < prefixLength(); i++)
 					rei2 = rei2.after();
 
 				Formula looping = rei.implies(rei2);
 				for (int i = loop + 1; i < prefixLength(); i++) {
-					rei = states.get(i).formulate(bounds, reif, slcs.getValue(), someDisj, !localUniv);
+					rei = states.get(i).formulate(reif, slcs.getValue(), someDisj, bounds, !localUniv);
 					rei2 = rei;
 					for (int k = loop; k < prefixLength(); k++)
 						rei2 = rei2.after();

--- a/src/main/java/kodkod/util/nodes/PrettyPrinter.java
+++ b/src/main/java/kodkod/util/nodes/PrettyPrinter.java
@@ -349,8 +349,8 @@ public final class PrettyPrinter {
 		 * parenthesized if it's an instance of binary expression or an if expression. **/
 		// [HASLab]
 		public void visit(TempExpression node) { 
-			keyword(node.op());
 			visitChild(node.expression(), parenthesize(node.op(), node.expression()));
+			append(node.op());
 		}
 
 

--- a/src/test/java/kodkod/test/pardinus/ReificationTests.java
+++ b/src/test/java/kodkod/test/pardinus/ReificationTests.java
@@ -83,9 +83,9 @@ public class ReificationTests {
 		opt.reporter().debug(inst.toString());
 //		relations: {a=[[A2]], b=[[B2]]}
 
-		assertEquals("((a = $$A2$$) and (b = $$B2$$))", inst.formulate(bounds.clone(), x, formula, false).toString());
+		assertEquals("((a = $$A2$$) and (b = $$B2$$))", inst.formulate(x, formula, false, bounds.clone()).toString());
 
-		formula = formula.and(inst.formulate(bounds, x, formula, false).not());
+		formula = formula.and(inst.formulate(x, formula, false, bounds).not());
 
 		inst = new Instance(uni);
 		inst.add(a, f.range(f.tuple("A1"),f.tuple("A2")));
@@ -96,9 +96,9 @@ public class ReificationTests {
 //		relations: {a=[[A1], [A2]], b=[[B1], [B2]], $$A2$$=[[A2]], $$B2$$=[[B2]], $$A0$$=[[A0]], $$A1$$=[[A1]], $$B0$$=[[B0]], $$B1$$=[[B1]]}
 
 		assertEquals("((a = ($$A1$$ + $$A2$$)) and (b = ($$B1$$ + $$B2$$)))",
-				inst.formulate(bounds.clone(), x, formula, false).toString());
+				inst.formulate(x, formula, false, bounds.clone()).toString());
 
-		formula = formula.and(inst.formulate(bounds, x, formula, false).not());
+		formula = formula.and(inst.formulate(x, formula, false, bounds).not());
 
 		inst = new Instance(uni);
 		inst.add(a, f.range(f.tuple("A1"),f.tuple("A2")));
@@ -109,7 +109,7 @@ public class ReificationTests {
 //		relations: {a=[[A1], [A2]], b=[[B2]], $$A1$$=[[A1]], $$A2$$=[[A2]], $$B1$$=[[B1]], $$B2$$=[[B2]], $$A0$$=[[A0]], $$B0$$=[[B0]]}
 
 		assertEquals("((a = ($$A1$$ + $$A2$$)) and (b = $$B2$$))",
-				inst.formulate(bounds.clone(), x, formula, false).toString());
+				inst.formulate(x, formula, false, bounds.clone()).toString());
 
 	}
 
@@ -159,7 +159,7 @@ public class ReificationTests {
 
 		assertEquals(
 				"(((a = none) and after((a = (($$A0$$ + $$A1$$) + $$A2$$)))) and always((((a = none) implies after(after((a = none)))) and ((a = (($$A0$$ + $$A1$$) + $$A2$$)) implies after(after((a = (($$A0$$ + $$A1$$) + $$A2$$))))))))",
-				inst.formulate(bounds.clone(), x, formula, false).toString());
+				inst.formulate(x, formula, false, bounds.clone()).toString());
 
 		inst0 = new Instance(uni);
 		inst0.add(a, f.setOf("A"+(n-1)));
@@ -178,7 +178,7 @@ public class ReificationTests {
 
 		assertEquals(
 				"(((a = $$A2$$) and after((a = ($$A0$$ + $$A1$$)))) and always((((a = $$A2$$) implies after(after((a = $$A2$$)))) and ((a = ($$A0$$ + $$A1$$)) implies after(after((a = ($$A0$$ + $$A1$$))))))))",
-				inst.formulate(bounds.clone(), x, formula, false).toString());
+				inst.formulate(x, formula, false, bounds.clone()).toString());
 	}
 
 	/* Temporal reification. */
@@ -233,7 +233,7 @@ public class ReificationTests {
 
 		assertEquals(
 				"((((a = ($$A1$$ + $$A2$$)) and (b = none)) and after((((a = ($$A0$$ + $$A2$$)) and (b = $$B2$$)) and after(((a = $$A1$$) and (b = $$B1$$)))))) and after(always(((((a = ($$A0$$ + $$A2$$)) and (b = $$B2$$)) implies after(after(((a = ($$A0$$ + $$A2$$)) and (b = $$B2$$))))) and (((a = $$A1$$) and (b = $$B1$$)) implies after(after(((a = $$A1$$) and (b = $$B1$$)))))))))",
-				inst.formulate(bounds.clone(), x, formula, false).toString());
+				inst.formulate(x, formula, false, bounds.clone()).toString());
 
 		inst0 = new Instance(uni);
 		inst0.add(a, f.setOf("A2"));
@@ -257,7 +257,7 @@ public class ReificationTests {
 
 		assertEquals(
 				"((((a = $$A2$$) and (b = none)) and after((((a = $$A1$$) and (b = $$B2$$)) and after(((a = ($$A0$$ + $$A2$$)) and (b = $$B1$$)))))) and after(always(((((a = $$A1$$) and (b = $$B2$$)) implies after(after(((a = $$A1$$) and (b = $$B2$$))))) and (((a = ($$A0$$ + $$A2$$)) and (b = $$B1$$)) implies after(after(((a = ($$A0$$ + $$A2$$)) and (b = $$B1$$)))))))))",
-				inst.formulate(bounds.clone(), x, formula, false).toString());
+				inst.formulate(x, formula, false, bounds.clone()).toString());
 
 	}
 
@@ -532,9 +532,9 @@ public class ReificationTests {
 
 //		relations: {a=[[A2]], b=[[B2]]}
 
-		assertEquals("((a = A2) and (b = B2))", inst.formulate(bounds.clone(), x, formula, true).toString());
+		assertEquals("((a = A2) and (b = B2))", inst.formulate(x, formula, true, bounds.clone()).toString());
 
-		formula = formula.and(inst.formulate(bounds, x, formula, true).not());
+		formula = formula.and(inst.formulate(x, formula, true, bounds).not());
 
 		inst = new Instance(uni);
 		inst.add(a, f.setOf("A1","A2"));
@@ -547,9 +547,9 @@ public class ReificationTests {
 //		relations: {a=[[A1], [A2]], b=[[B1], [B2]], $$A2$$=[[A2]], $$B2$$=[[B2]], $$A0$$=[[A0]], $$A1$$=[[A1]], $$B0$$=[[B0]], $$B1$$=[[B1]]}
 
 		assertEquals("((a = (A1 + A2)) and (b = (B1 + B2)))",
-				inst.formulate(bounds.clone(), x, formula, true).toString());
+				inst.formulate(x, formula, true, bounds.clone()).toString());
 
-		formula = formula.and(inst.formulate(bounds, x, formula, true).not());
+		formula = formula.and(inst.formulate(x, formula, true, bounds).not());
 
 		inst = new Instance(uni);
 		inst.add(a, f.setOf("A1","A2"));
@@ -562,7 +562,7 @@ public class ReificationTests {
 //		relations: {a=[[A1], [A2]], b=[[B2]], $$A1$$=[[A1]], $$A2$$=[[A2]], $$B1$$=[[B1]], $$B2$$=[[B2]], $$A0$$=[[A0]], $$B0$$=[[B0]]}
 
 		assertEquals("((a = (A1 + A2)) and (b = B2))",
-				inst.formulate(bounds.clone(), x, formula, true).toString());
+				inst.formulate(x, formula, true, bounds.clone()).toString());
 
 	}
 
@@ -616,7 +616,7 @@ public class ReificationTests {
 
 		assertEquals(
 				"(some [A1: one univ, B2: one univ, A2: one univ, B0: one univ, A0: one univ, B1: one univ] | (((((((A1 + B2) + A2) + B0) + A0) + B1) = univ) and (((a = none) and after((a = ((A0 + A1) + A2)))) and always((((a = none) implies after(after((a = none)))) and ((a = ((A0 + A1) + A2)) implies after(after((a = ((A0 + A1) + A2))))))))))",
-				inst.formulate(bounds.clone(), x, formula, true).toString());
+				inst.formulate(x, formula, true, bounds.clone()).toString());
 
 		inst0 = new Instance(uni);
 		inst0.add(a, f.setOf("A2"));
@@ -635,7 +635,7 @@ public class ReificationTests {
 		
 		assertEquals(
 				"(some [A1: one univ, B2: one univ, A2: one univ, B0: one univ, A0: one univ, B1: one univ] | (((((((A1 + B2) + A2) + B0) + A0) + B1) = univ) and (((a = A2) and after((a = (A0 + A1)))) and always((((a = A2) implies after(after((a = A2)))) and ((a = (A0 + A1)) implies after(after((a = (A0 + A1))))))))))",
-				inst.formulate(bounds.clone(), x, formula, true).toString());
+				inst.formulate(x, formula, true, bounds.clone()).toString());
 
 	}
 
@@ -691,7 +691,7 @@ public class ReificationTests {
 
 		assertEquals(
 				"(some [A1: one univ, B2: one univ, A2: one univ, B0: one univ, A0: one univ, B1: one univ] | (((((((A1 + B2) + A2) + B0) + A0) + B1) = univ) and ((((a = (A1 + A2)) and (b = none)) and after((((a = none) and (b = B2)) and after(((a = A0) and (b = B2)))))) and after(always(((((a = none) and (b = B2)) implies after(after(((a = none) and (b = B2))))) and (((a = A0) and (b = B2)) implies after(after(((a = A0) and (b = B2)))))))))))",
-				inst.formulate(bounds.clone(), x, formula, true).toString());
+				inst.formulate(x, formula, true, bounds.clone()).toString());
 
 		inst0 = new Instance(uni);
 		inst0.add(a, f.setOf("A1","A2"));
@@ -715,7 +715,7 @@ public class ReificationTests {
 
 		assertEquals(
 				"(some [A1: one univ, B2: one univ, A2: one univ, B0: one univ, A0: one univ, B1: one univ] | (((((((A1 + B2) + A2) + B0) + A0) + B1) = univ) and ((((a = (A1 + A2)) and (b = none)) and after((((a = none) and (b = B2)) and after(((a = A0) and (b = B2)))))) and after(always(((((a = none) and (b = B2)) implies after(after(((a = none) and (b = B2))))) and (((a = A0) and (b = B2)) implies after(after(((a = A0) and (b = B2)))))))))))",
-				inst.formulate(bounds.clone(), x, formula, true).toString());
+				inst.formulate(x, formula, true, bounds.clone()).toString());
 
 	}
 

--- a/src/test/java/kodkod/test/pardinus/ReificationTests.java
+++ b/src/test/java/kodkod/test/pardinus/ReificationTests.java
@@ -532,7 +532,7 @@ public class ReificationTests {
 
 //		relations: {a=[[A2]], b=[[B2]]}
 
-		assertEquals("((a = $$A2$$) and (b = $$B2$$))", inst.formulate(bounds.clone(), x, formula, true).toString());
+		assertEquals("((a = A2) and (b = B2))", inst.formulate(bounds.clone(), x, formula, true).toString());
 
 		formula = formula.and(inst.formulate(bounds, x, formula, true).not());
 
@@ -546,7 +546,7 @@ public class ReificationTests {
 
 //		relations: {a=[[A1], [A2]], b=[[B1], [B2]], $$A2$$=[[A2]], $$B2$$=[[B2]], $$A0$$=[[A0]], $$A1$$=[[A1]], $$B0$$=[[B0]], $$B1$$=[[B1]]}
 
-		assertEquals("((a = ($$A1$$ + $$A2$$)) and (b = ($$B1$$ + $$B2$$)))",
+		assertEquals("((a = (A1 + A2)) and (b = (B1 + B2)))",
 				inst.formulate(bounds.clone(), x, formula, true).toString());
 
 		formula = formula.and(inst.formulate(bounds, x, formula, true).not());
@@ -561,7 +561,7 @@ public class ReificationTests {
 
 //		relations: {a=[[A1], [A2]], b=[[B2]], $$A1$$=[[A1]], $$A2$$=[[A2]], $$B1$$=[[B1]], $$B2$$=[[B2]], $$A0$$=[[A0]], $$B0$$=[[B0]]}
 
-		assertEquals("((a = ($$A1$$ + $$A2$$)) and (b = $$B2$$))",
+		assertEquals("((a = (A1 + A2)) and (b = B2))",
 				inst.formulate(bounds.clone(), x, formula, true).toString());
 
 	}

--- a/src/test/java/kodkod/test/pardinus/decomp/ExplorationQualityTests.java
+++ b/src/test/java/kodkod/test/pardinus/decomp/ExplorationQualityTests.java
@@ -364,45 +364,33 @@ public class ExplorationQualityTests {
 		
 		// just fixing, solution never changes
 		sol = sols.nextS(2,2, new HashSet<Relation>());
-		assertTrue(sol.sat());
+		assertFalse(sol.sat());
 		assertTrue(sols.hasNext());
-		assertEquals(4, ((TemporalInstance) sol.instance()).prefixLength());	
-		opt.reporter().debug(sol.instance().toString());
 
 		// just fixing, solution never changes
 		sol = sols.nextS(2,2, new HashSet<Relation>());
-		assertTrue(sol.sat());
+		assertFalse(sol.sat());
 		assertTrue(sols.hasNext());
-		assertEquals(4, ((TemporalInstance) sol.instance()).prefixLength());	
-		opt.reporter().debug(sol.instance().toString());
 
 		// just fixing, solution never changes
 		sol = sols.nextS(2,2, new HashSet<Relation>());
-		assertTrue(sol.sat());
+		assertFalse(sol.sat());
 		assertTrue(sols.hasNext());
-		assertEquals(4, ((TemporalInstance) sol.instance()).prefixLength());	
-		opt.reporter().debug(sol.instance().toString());
 
 		// just fixing, solution never changes
 		sol = sols.nextS(2,2, new HashSet<Relation>());
-		assertTrue(sol.sat());
+		assertFalse(sol.sat());
 		assertTrue(sols.hasNext());
-		assertEquals(4, ((TemporalInstance) sol.instance()).prefixLength());	
-		opt.reporter().debug(sol.instance().toString());
 
 		// beyond prefix length, must unroll
 		sol = sols.nextS(2,5, new HashSet<Relation>());
-		assertTrue(sol.sat());
+		assertFalse(sol.sat());
 		assertTrue(sols.hasNext());
-		assertEquals(7, ((TemporalInstance) sol.instance()).prefixLength());	
-		opt.reporter().debug(sol.instance().toString());
 
 		// prefix is already fixed up to 6
 		sol = sols.nextS(0,1, new HashSet<Relation>());
-		assertTrue(sol.sat());
+		assertFalse(sol.sat());
 		assertTrue(sols.hasNext());
-		assertEquals(7, ((TemporalInstance) sol.instance()).prefixLength());	
-		opt.reporter().debug(sol.instance().toString());
 		
 		// beyond the maximum trace length
 		sol = sols.nextS(9,2, new HashSet<Relation>());

--- a/src/test/java/kodkod/test/pardinus/decomp/TemporalSymmetryTests.java
+++ b/src/test/java/kodkod/test/pardinus/decomp/TemporalSymmetryTests.java
@@ -36,7 +36,6 @@ import kodkod.engine.Solution.Outcome;
 import kodkod.engine.config.DecomposedOptions.DMode;
 import kodkod.engine.config.AbstractReporter;
 import kodkod.engine.config.ExtendedOptions;
-import kodkod.engine.config.SLF4JReporter;
 import kodkod.engine.config.Options;
 import kodkod.engine.config.Reporter;
 import kodkod.engine.decomp.DModel;

--- a/src/test/java/kodkod/test/pardinus/temporal/ExplorationQualityTests.java
+++ b/src/test/java/kodkod/test/pardinus/temporal/ExplorationQualityTests.java
@@ -358,45 +358,33 @@ public class ExplorationQualityTests {
 		
 		// just fixing, solution never changes
 		sol = sols.nextS(2,2, new HashSet<Relation>());
-		assertTrue(sol.sat());
+		assertFalse(sol.sat());
 		assertTrue(sols.hasNext());
-		assertEquals(4, ((TemporalInstance) sol.instance()).prefixLength());	
-		opt.reporter().debug(sol.instance().toString());
 
 		// just fixing, solution never changes
 		sol = sols.nextS(2,2, new HashSet<Relation>());
-		assertTrue(sol.sat());
+		assertFalse(sol.sat());
 		assertTrue(sols.hasNext());
-		assertEquals(4, ((TemporalInstance) sol.instance()).prefixLength());	
-		opt.reporter().debug(sol.instance().toString());
 
 		// just fixing, solution never changes
 		sol = sols.nextS(2,2, new HashSet<Relation>());
-		assertTrue(sol.sat());
+		assertFalse(sol.sat());
 		assertTrue(sols.hasNext());
-		assertEquals(4, ((TemporalInstance) sol.instance()).prefixLength());	
-		opt.reporter().debug(sol.instance().toString());
 
 		// just fixing, solution never changes
 		sol = sols.nextS(2,2, new HashSet<Relation>());
-		assertTrue(sol.sat());
+		assertFalse(sol.sat());
 		assertTrue(sols.hasNext());
-		assertEquals(4, ((TemporalInstance) sol.instance()).prefixLength());	
-		opt.reporter().debug(sol.instance().toString());
 
 		// beyond prefix length, must unroll
 		sol = sols.nextS(2,5, new HashSet<Relation>());
-		assertTrue(sol.sat());
+		assertFalse(sol.sat());
 		assertTrue(sols.hasNext());
-		assertEquals(7, ((TemporalInstance) sol.instance()).prefixLength());	
-		opt.reporter().debug(sol.instance().toString());
 
 		// prefix is already fixed up to 6
 		sol = sols.nextS(0,1, new HashSet<Relation>());
-		assertTrue(sol.sat());
+		assertFalse(sol.sat());
 		assertTrue(sols.hasNext());
-		assertEquals(7, ((TemporalInstance) sol.instance()).prefixLength());	
-		opt.reporter().debug(sol.instance().toString());
 		
 		// beyond the maximum trace length
 		sol = sols.nextS(9,2, new HashSet<Relation>());

--- a/src/test/java/kodkod/test/pardinus/temporal/ExplorationQualityTests.java
+++ b/src/test/java/kodkod/test/pardinus/temporal/ExplorationQualityTests.java
@@ -25,6 +25,7 @@ package kodkod.test.pardinus.temporal;
 
 import kodkod.ast.Formula;
 import kodkod.ast.Relation;
+import kodkod.ast.Variable;
 import kodkod.engine.Explorer;
 import kodkod.engine.PardinusSolver;
 import kodkod.engine.Solution;
@@ -755,6 +756,67 @@ public class ExplorationQualityTests {
 		assertFalse(sol.sat());
 		assertFalse(sols.hasNextC());
 
+		solver.free();
+	}
+	
+	@Test
+	public void testStateWiseSB() {
+		int n = 3;
+
+		Relation file = Relation.unary_variable("F");
+		Relation trash = Relation.unary_variable("T");
+		
+		Object[] atoms = new Object[n];
+		for (int i = 0; i < n; i ++)
+			atoms[i] = "A"+i;
+		
+		Universe uni = new Universe(atoms);
+		TupleFactory f = uni.factory();
+		TupleSet as = f.range(f.tuple("A0"), f.tuple("A"+(n-1)));
+
+		PardinusBounds bounds = new PardinusBounds(uni);
+		bounds.bound(file, as);
+		bounds.bound(trash, as);
+
+		Formula type=trash.in(file).always();
+		Formula init=trash.no();
+		Variable vr=Variable.unary("f");
+		Formula delete=((vr.in(trash).not()).and(trash.prime().eq(trash.union(vr)))).and(file.prime().eq(file));
+		Formula retore=((vr.in(trash)).and(trash.prime().eq(trash.difference(vr)))).and(file.prime().eq(file));
+		Formula x15=(delete.or(retore)).forSome(vr.oneOf(file));
+		Formula empty=(trash.some().and(trash.prime().no())).and(file.prime().eq(file.difference(trash)));
+		Formula act=x15.or(empty);
+		Formula stutter = (file.prime().eq(file)).and(trash.prime().eq(trash));
+		Formula step=act.or(stutter).always();
+		Formula x55=file.eq(file);
+		Formula x56=trash.eq(trash);
+		Formula formula=Formula.and(type, init, step, x55, x56);
+
+
+		ExtendedOptions opt = new ExtendedOptions();
+
+//		opt.setReporter(new SLF4JReporter());
+		opt.setRunTemporal(true);
+		opt.setRunUnbounded(false);
+		opt.setRunDecomposed(false);
+		opt.setMaxTraceLength(4);
+		opt.setSolver(SATFactory.MiniSat);
+		PardinusSolver solver = new PardinusSolver(opt);
+		
+		Set<Relation> changes = new HashSet<Relation>();
+		changes.add(file);
+		changes.add(trash);
+		
+		Explorer<Solution> sols = (Explorer<Solution>) solver.solveAll(formula, bounds);
+		Solution sol = sols.next();
+		System.out.println(sol.instance());
+		sol = sols.nextS(0, 1, changes);
+		System.out.println(sol.instance());
+		sol = sols.nextS(1, 1, changes);
+		System.out.println(sol.instance());
+		sol = sols.nextS(1, 1, changes);
+		assertFalse("returned two isomorphic instance, bad statewise sbp", sol.sat());
+		
 		solver.free();
 	}
 }

--- a/src/test/java/kodkod/test/pardinus/temporal/ExplorationQualityTests.java
+++ b/src/test/java/kodkod/test/pardinus/temporal/ExplorationQualityTests.java
@@ -857,10 +857,6 @@ public class ExplorationQualityTests {
 		opt.setSolver(SATFactory.MiniSat);
 		PardinusSolver solver = new PardinusSolver(opt);
 		
-		Set<Relation> changes = new HashSet<Relation>();
-		changes.add(a);
-		changes.add(b);
-		
 		Explorer<Solution> sols = (Explorer<Solution>) solver.solveAll(formula, bounds);
 		Solution sol = sols.next();
 		while (sols.hasNext()) {
@@ -868,6 +864,47 @@ public class ExplorationQualityTests {
 			assertFalse("symmetry not broken statewise", eval.evaluate(b).toString().equals("[[A0]]"));
 			sol = sols.nextP();
 		}
+		
+		solver.free();
+	}
+	
+	@Test
+	public void testConfigNoConfigs() {
+		int n = 2;
+
+		Relation a = Relation.unary_variable("a");
+		
+		Object[] atoms = new Object[n];
+		for (int i = 0; i < n; i ++)
+			atoms[i] = "A"+i;
+		
+		Universe uni = new Universe(atoms);
+		TupleFactory f = uni.factory();
+		TupleSet as = f.range(f.tuple("A0"), f.tuple("A"+(n-1)));
+
+		PardinusBounds bounds = new PardinusBounds(uni);
+		bounds.bound(a, as);
+
+		Formula formula = a.eq(a.prime()).not().always();
+
+		ExtendedOptions opt = new ExtendedOptions();
+
+//		opt.setReporter(new SLF4JReporter());
+		opt.setRunTemporal(true);
+		opt.setRunUnbounded(false);
+		opt.setRunDecomposed(false);
+		opt.setMaxTraceLength(2);
+		opt.setSolver(SATFactory.MiniSat);
+		PardinusSolver solver = new PardinusSolver(opt);
+		
+		Explorer<Solution> sols = (Explorer<Solution>) solver.solveAll(formula, bounds);
+		int c = 0;
+		while (sols.hasNextC()) {
+			sols.nextC();
+			c++;
+		}
+		
+		assertEquals("nothing to change, should not have iterated",1,c);
 		
 		solver.free();
 	}

--- a/src/test/java/kodkod/test/pardinus/temporal/ExplorationQualityTests.java
+++ b/src/test/java/kodkod/test/pardinus/temporal/ExplorationQualityTests.java
@@ -811,11 +811,8 @@ public class ExplorationQualityTests {
 		
 		Explorer<Solution> sols = (Explorer<Solution>) solver.solveAll(formula, bounds);
 		Solution sol = sols.next();
-		System.out.println(sol.instance());
 		sol = sols.nextS(0, 1, changes);
-		System.out.println(sol.instance());
 		sol = sols.nextS(1, 1, changes);
-		System.out.println(sol.instance());
 		sol = sols.nextS(1, 1, changes);
 		assertFalse("returned two isomorphic instance, bad statewise sbp", sol.sat());
 		

--- a/src/test/java/kodkod/test/pardinus/temporal/InstanceExpansionTests.java
+++ b/src/test/java/kodkod/test/pardinus/temporal/InstanceExpansionTests.java
@@ -415,7 +415,7 @@ public class InstanceExpansionTests {
 		PardinusSolver solver = new PardinusSolver(opt);
 
 		Explorer<Solution> solution = solver.solveAll(formula, bounds);
-		TemporalInstance inst = (TemporalInstance) solution.next().instance();
+		TemporalInstance inst = (TemporalInstance) solution.nextC().instance();
 		Evaluator e1 = new Evaluator(inst);
 		for (int i = 0; i < inst.prefixLength() + 3; i++) {
 			Evaluator e2 = new Evaluator(inst.state(i));

--- a/src/test/java/kodkod/test/pardinus/temporal/TemporalUCoreMappingTest.java
+++ b/src/test/java/kodkod/test/pardinus/temporal/TemporalUCoreMappingTest.java
@@ -111,7 +111,7 @@ public class TemporalUCoreMappingTest {
         assertFalse(hCore.contains(f10));
         assertFalse(hCore.contains(f11));
         
-        System.out.println(hCore);
+        opt.reporter().debug(hCore.toString());
 	}
 	
 	@Test
@@ -161,7 +161,7 @@ public class TemporalUCoreMappingTest {
         assertFalse(hCore.contains(f10));
         assertFalse(hCore.contains(f11));
         
-        System.out.println(hCore);
+        opt.reporter().debug(hCore.toString());
 	}
 	
 	@Test
@@ -211,7 +211,7 @@ public class TemporalUCoreMappingTest {
         assertFalse(hCore.contains(f10));
         assertTrue(hCore.contains(f11));
         
-        System.out.println(hCore);
+        opt.reporter().debug(hCore.toString());
 	}
 
 	@Test
@@ -264,7 +264,7 @@ public class TemporalUCoreMappingTest {
         assertFalse(hCore.contains(f11));
         assertFalse(hCore.contains(f20));
         
-        System.out.println(hCore);
+        opt.reporter().debug(hCore.toString());
 	}
 	
 	@Test
@@ -317,7 +317,7 @@ public class TemporalUCoreMappingTest {
         assertFalse(hCore.contains(f11));
         assertTrue(hCore.contains(f20));
         
-        System.out.println(hCore);
+        opt.reporter().debug(hCore.toString());
 	}
 	
 	
@@ -371,7 +371,7 @@ public class TemporalUCoreMappingTest {
         assertTrue(hCore.contains(f11));
         assertTrue(hCore.contains(f20));
         
-        System.out.println(hCore);
+        opt.reporter().debug(hCore.toString());
 	}
 	
 	@Test
@@ -422,7 +422,7 @@ public class TemporalUCoreMappingTest {
         assertFalse(hCore.contains(f10));
         assertFalse(hCore.contains(f11));
         
-        System.out.println(hCore);
+        opt.reporter().debug(hCore.toString());
 	}
 
 }


### PR DESCRIPTION
Minor

- Changes to the instance to formula translation (no quantification for ints, allow restriction of univ)
- Forbid iteration when set of changing formulas is empty
- Fixed the pretty printing of primed expressions
- Fixed a bug on the generation of the statewise symmetry breaking predicate
- Additional tests for statewise symmetry breaking predicate