### PR TITLE
Add support for custom retargeting strategies

### DIFF
--- a/src/main/java/kodkod/engine/ExtendedSolver.java
+++ b/src/main/java/kodkod/engine/ExtendedSolver.java
@@ -167,7 +167,7 @@ public class ExtendedSolver extends AbstractKodkodSolver<PardinusBounds,Extended
 				try {				
 					cnf.valueOf(1); // fails if no previous solution
 					TargetSATSolver tcnf = (TargetSATSolver) cnf;
-					retargeter.retarget(tcnf, opt, transl);
+					retargeter.retarget(opt, transl);
 				} 
 				catch(IllegalStateException e) { }
 	
@@ -285,8 +285,9 @@ public class ExtendedSolver extends AbstractKodkodSolver<PardinusBounds,Extended
 		private class DefaultRetargeter implements Retargeter {
 
 			@Override
-			public void retarget(TargetSATSolver tcnf, ExtendedOptions opts, Translation transl) {
-
+			public void retarget(ExtendedOptions opts, Translation transl) {
+				assert(transl.cnf() instanceof TargetSATSolver);
+				TargetSATSolver tcnf = (TargetSATSolver)transl.cnf();
 				tcnf.clearTargets();
 				// [HASLab] if there are weights must iterate through the relations to find the literal's owner
 				if (weights != null) {

--- a/src/main/java/kodkod/engine/ExtendedSolver.java
+++ b/src/main/java/kodkod/engine/ExtendedSolver.java
@@ -166,8 +166,9 @@ public class ExtendedSolver extends AbstractKodkodSolver<PardinusBounds,Extended
 				// reconstructed at each step
 				try {				
 					cnf.valueOf(1); // fails if no previous solution
-					TargetSATSolver tcnf = (TargetSATSolver) cnf;
-					retargeter.retarget(opt, transl);
+					assert(opt == transl.options()); // assume: opts unmodified
+					retargeter.retarget(transl);
+
 				} 
 				catch(IllegalStateException e) { }
 	
@@ -285,9 +286,11 @@ public class ExtendedSolver extends AbstractKodkodSolver<PardinusBounds,Extended
 		private class DefaultRetargeter implements Retargeter {
 
 			@Override
-			public void retarget(ExtendedOptions opts, Translation transl) {
+			public void retarget(Translation transl) {
 				assert(transl.cnf() instanceof TargetSATSolver);
 				TargetSATSolver tcnf = (TargetSATSolver)transl.cnf();
+				assert(transl.options() instanceof ExtendedOptions);
+				ExtendedOptions opts = (ExtendedOptions) transl.options();
 				tcnf.clearTargets();
 				// [HASLab] if there are weights must iterate through the relations to find the literal's owner
 				if (weights != null) {

--- a/src/main/java/kodkod/engine/ExtendedSolver.java
+++ b/src/main/java/kodkod/engine/ExtendedSolver.java
@@ -49,6 +49,7 @@ import kodkod.util.ints.IntIterator;
  * @modified Nuno Macedo // [HASLab] model finding hierarchy
  * @modified Nuno Macedo // [HASLab] decomposed model finding
  * @modified Tiago Guimarães, Nuno Macedo // [HASLab] target-oriented model finding
+ * @modified Tim Nelson (Retargeter, DefaultRetargeter)
  */
 public class ExtendedSolver extends AbstractKodkodSolver<PardinusBounds,ExtendedOptions> implements
 		TargetOrientedSolver<ExtendedOptions>,
@@ -277,6 +278,10 @@ public class ExtendedSolver extends AbstractKodkodSolver<PardinusBounds,Extended
 			return next();
 		}
 
+		/**
+		 * Implements the default behavior of retargeting to the last instance found.
+		 * Uses the options' targetMode to decide whether to seek far from or close to the target.
+		 */
 		private class DefaultRetargeter implements Retargeter {
 
 			@Override

--- a/src/main/java/kodkod/engine/Retargeter.java
+++ b/src/main/java/kodkod/engine/Retargeter.java
@@ -1,0 +1,14 @@
+package kodkod.engine;
+
+import kodkod.engine.config.TargetOptions;
+import kodkod.engine.fol2sat.Translation;
+import kodkod.engine.satlab.TargetSATSolver;
+
+/**
+ * Describes a re-targeting strategy.
+ * This exposes the TargetSATSolver, Translation, etc. to
+ * enable maximum flexibility for the caller.
+ */
+public interface Retargeter {
+    void retarget(TargetSATSolver tcnf, TargetOptions.TMode mode, Translation transl, int primaryVars);
+}

--- a/src/main/java/kodkod/engine/Retargeter.java
+++ b/src/main/java/kodkod/engine/Retargeter.java
@@ -1,5 +1,6 @@
 package kodkod.engine;
 
+import kodkod.engine.config.ExtendedOptions;
 import kodkod.engine.config.TargetOptions;
 import kodkod.engine.fol2sat.Translation;
 import kodkod.engine.satlab.TargetSATSolver;
@@ -10,5 +11,5 @@ import kodkod.engine.satlab.TargetSATSolver;
  * enable maximum flexibility for the caller.
  */
 public interface Retargeter {
-    void retarget(TargetSATSolver tcnf, TargetOptions.TMode mode, Translation transl, int primaryVars);
+    void retarget(TargetSATSolver tcnf, ExtendedOptions opts, Translation transl);
 }

--- a/src/main/java/kodkod/engine/Retargeter.java
+++ b/src/main/java/kodkod/engine/Retargeter.java
@@ -15,14 +15,13 @@ import kodkod.engine.satlab.TargetSATSolver;
  */
 public interface Retargeter {
     /**
-     * The retarget method exposes the TargetSATSolver, Translation, etc. to enable maximum
+     * The retarget method exposes the Translation, etc. to enable maximum
      * flexibility for the caller; an empty retargeting method will implement standard
      * enumeration (with no retargeting); the solver will always issue a new clause
      * to exclude repeat instances regardless of retargeting strategy.
      *
-     * @param tcnf The underlying TargetSATSolver instance, for adding new clauses, changing target, etc.
      * @param opts The options used by the solver
      * @param transl The current boolean Translation (for retrieving primary variables, etc.)
      */
-    void retarget(TargetSATSolver tcnf, ExtendedOptions opts, Translation transl);
+    void retarget(ExtendedOptions opts, Translation transl);
 }

--- a/src/main/java/kodkod/engine/Retargeter.java
+++ b/src/main/java/kodkod/engine/Retargeter.java
@@ -1,15 +1,28 @@
 package kodkod.engine;
 
 import kodkod.engine.config.ExtendedOptions;
-import kodkod.engine.config.TargetOptions;
 import kodkod.engine.fol2sat.Translation;
 import kodkod.engine.satlab.TargetSATSolver;
 
 /**
- * Describes a re-targeting strategy.
- * This exposes the TargetSATSolver, Translation, etc. to
- * enable maximum flexibility for the caller.
+ * A {@link Retargeter} describes a re-targeting strategy for target-oriented
+ * model-finding. Once registered via {@link ExtendedOptions}, it will be called
+ * by the underlying solver after every instance produced. For the default
+ * behavior, which is followed when no Retargeter is registered, see the
+ * private class DefaultRetargeter within {@link ExtendedSolver}.
+ *
+ * @author Tim Nelson
  */
 public interface Retargeter {
+    /**
+     * The retarget method exposes the TargetSATSolver, Translation, etc. to enable maximum
+     * flexibility for the caller; an empty retargeting method will implement standard
+     * enumeration (with no retargeting); the solver will always issue a new clause
+     * to exclude repeat instances regardless of retargeting strategy.
+     *
+     * @param tcnf The underlying TargetSATSolver instance, for adding new clauses, changing target, etc.
+     * @param opts The options used by the solver
+     * @param transl The current boolean Translation (for retrieving primary variables, etc.)
+     */
     void retarget(TargetSATSolver tcnf, ExtendedOptions opts, Translation transl);
 }

--- a/src/main/java/kodkod/engine/Retargeter.java
+++ b/src/main/java/kodkod/engine/Retargeter.java
@@ -2,7 +2,6 @@ package kodkod.engine;
 
 import kodkod.engine.config.ExtendedOptions;
 import kodkod.engine.fol2sat.Translation;
-import kodkod.engine.satlab.TargetSATSolver;
 
 /**
  * A {@link Retargeter} describes a re-targeting strategy for target-oriented
@@ -20,8 +19,9 @@ public interface Retargeter {
      * enumeration (with no retargeting); the solver will always issue a new clause
      * to exclude repeat instances regardless of retargeting strategy.
      *
-     * @param opts The options used by the solver
+     * Note that the TargetSATSolver instance is transl.cnf()
+     *       and the ExtendedOptions instance is transl.options()
      * @param transl The current boolean Translation (for retrieving primary variables, etc.)
      */
-    void retarget(ExtendedOptions opts, Translation transl);
+    void retarget(Translation transl);
 }

--- a/src/main/java/kodkod/engine/config/ExtendedOptions.java
+++ b/src/main/java/kodkod/engine/config/ExtendedOptions.java
@@ -92,6 +92,9 @@ public class ExtendedOptions extends Options implements BoundedOptions,
 	}
 
 	@Override
+	/**
+	 * See {@link Retargeter}.
+	 */
 	public void setRetargeter(Retargeter r) {
 		this.retargeter = r;
 	}

--- a/src/main/java/kodkod/engine/config/ExtendedOptions.java
+++ b/src/main/java/kodkod/engine/config/ExtendedOptions.java
@@ -22,6 +22,8 @@
  */
 package kodkod.engine.config;
 
+import kodkod.engine.Retargeter;
+
 /**
  * Stores information about various user-level translation and analysis options.
  * with support for every Pardinus functionality (temporal, unbounded,
@@ -59,12 +61,14 @@ public class ExtendedOptions extends Options implements BoundedOptions,
 		this.trace_length = options.trace_length;
 		this.min_trace_length = options.min_trace_length;
 		this.name = options.name;
+		this.retargeter = options.retargeter;
 	}
 
 	// target-oriented solving
 
 	private boolean run_target = false;
 	private TMode target_mode = TMode.CLOSE;
+	private Retargeter retargeter = null;
 	/**
 	 * {@inheritDoc}
 	 */
@@ -85,6 +89,16 @@ public class ExtendedOptions extends Options implements BoundedOptions,
 	 */
 	public TMode targetMode() {
 		return target_mode;
+	}
+
+	@Override
+	public void setRetargeter(Retargeter r) {
+		this.retargeter = r;
+	}
+
+	@Override
+	public Retargeter retargeter() {
+		return retargeter;
 	}
 
 	/**
@@ -259,6 +273,7 @@ public class ExtendedOptions extends Options implements BoundedOptions,
 		c.setMaxTraceLength(trace_length);
 		c.setMinTraceLength(min_trace_length);
 		c.name = name;
+		c.setRetargeter(retargeter);
 		return c;
 	}
 
@@ -286,6 +301,8 @@ public class ExtendedOptions extends Options implements BoundedOptions,
 		b.append(trace_length);
 		b.append("\n run unbounded: ");
 		b.append(run_unbounded);
+		b.append("\n custom retargeter?: ");
+		b.append(retargeter != null);
 		return b.toString();
 	}
 
@@ -305,5 +322,7 @@ public class ExtendedOptions extends Options implements BoundedOptions,
 		this.name = name;
 		return true;
 	}
+
+
 
 }

--- a/src/main/java/kodkod/engine/config/TargetOptions.java
+++ b/src/main/java/kodkod/engine/config/TargetOptions.java
@@ -22,6 +22,7 @@
  */
 package kodkod.engine.config;
 
+import kodkod.engine.Retargeter;
 import kodkod.engine.TargetOrientedSolver;
 
 /**
@@ -51,6 +52,21 @@ public interface TargetOptions extends PardinusOptions {
 	 * @return the target-oriented mode followed by the solver.
 	 */
 	public TMode targetMode();
+
+	/**
+	 * Provides the solver with a re-targeting strategy to
+	 * apply between instances returned. If null, will apply
+	 * Pardinus standard re-targeting.
+	 *
+	 * @param r retargeting strategy object
+	 */
+	void setRetargeter(Retargeter r);
+
+	/**
+	 * Get the current retargeting strategy
+	 * @return the retargeting strategy used by the solver
+	 */
+	public Retargeter retargeter();
 
 	/**
 	 * Instructs the {@link TargetOrientedSolver solver} to solve the problem in

--- a/src/main/java/kodkod/examples/pardinus/target/NoRetargeting.java
+++ b/src/main/java/kodkod/examples/pardinus/target/NoRetargeting.java
@@ -1,0 +1,133 @@
+package kodkod.examples.pardinus.target;
+/*
+  Experimenting with Pardinus
+  Tim Nelson, August 2020
+
+  Sets up a target-oriented model-finding problem
+  with 2 atoms and 3 unary relations: p, q, and r.
+
+  Target for p: both atoms.
+  Target for q: no atoms.
+  Target for r: (absent).
+
+  Constraint: all 3 relations are non-empty.
+ */
+
+import kodkod.ast.*;
+import kodkod.engine.*;
+import kodkod.engine.config.ExtendedOptions;
+import kodkod.engine.config.TargetOptions;
+import kodkod.engine.fol2sat.Translation;
+import kodkod.engine.satlab.SATFactory;
+import kodkod.engine.satlab.TargetSATSolver;
+import kodkod.instance.*;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class NoRetargeting {
+
+    public static void main(String[] args) {
+        Relation p = Relation.unary("P");
+        Relation q = Relation.unary("Q");
+        Relation r = Relation.unary("R");
+
+        Set<Object> atoms = new HashSet<>();
+        int NATOMS = 2;
+        for (int i = 0; i < NATOMS; i++) {
+            atoms.add("Atom"+i);
+        }
+        Universe u = new Universe(atoms);
+
+        PardinusBounds pb = new PardinusBounds(u);
+        pb.bound(p, u.factory().allOf(1));
+        pb.bound(q, u.factory().allOf(1));
+        pb.bound(r, u.factory().allOf(1));
+
+        // Target P = all, Q = none; R has no target
+        // (but target won't satisfy fmla)
+        pb.setTarget(p, u.factory().allOf(1));
+        pb.setTarget(q, u.factory().noneOf(1));
+        System.out.println("target for p: "+pb.target(p));
+        System.out.println("target for q: "+pb.target(q));
+        System.out.println("target for r: "+pb.target(r));
+
+        Formula f = p.some().and(q.some()).and(r.some());
+        System.out.println("formula = "+f);
+
+        ///////////////////////////////////////////////////
+
+        ExtendedOptions eo = new ExtendedOptions();
+        eo.setRunTarget(true);
+        eo.setSolver(SATFactory.PMaxSAT4J);
+        eo.setSymmetryBreaking(20);
+        eo.setLogTranslation(0);
+        eo.setBitwidth(1); // minimal
+        eo.setRetargeter(new Retargeter() {
+            @Override
+            public void retarget(TargetSATSolver tcnf, TargetOptions.TMode mode, Translation transl, int primaryVars) {
+                // Do nothing; keep initial target
+            }
+        });
+
+        // We want to enumerate instances of maximal distance from
+        // the target. But Pardinus will always produce a *first*
+        // instance as close as possible to the initial target.
+        // So instead, flip the goal. Target-mode doesn't matter here
+        // since it's all about retargeting and we're providing a retargeter.
+        eo.setTargetMode(TargetOptions.TMode.CLOSE);
+
+        // Flip initial target
+        PardinusBounds origpb = pb.clone();
+        for(Relation rel : pb.targets().keySet()) {
+            TupleSet tuples = u.factory().allOf(rel.arity());
+            tuples.removeAll(pb.targets().get(rel));
+            pb.setTarget(rel, tuples);
+        }
+        System.out.println("flipped target for p: "+pb.target(p));
+        System.out.println("flipped target for q: "+pb.target(q));
+        System.out.println("flipped target for r: "+pb.target(r));
+
+        // Break with good interface use
+        PardinusSolver s = new PardinusSolver(eo);
+
+        ///////////////////////////////////////////////////
+
+        // Note: new "Explorer" iterator.
+        Explorer<Solution> sols =  s.solveAll(f, pb);
+        int count = 0;
+        while(sols.hasNext()) {
+            Solution sol = sols.next();
+            count++;
+            if(sol.sat()) {
+                System.out.println("-------------------");
+                System.out.println(sol.instance().relationTuples());
+                System.out.println("dist from target = "+computeDist(origpb, sol.instance()));
+            }
+        }
+        System.out.println("total number of instances: "+count);
+    }
+
+    /**
+     * Compute Hamming dist between target and instance
+     * Relations not in target aren't counted.
+     *
+     * @param pb
+     * @param instance
+     * @return
+     */
+    private static int computeDist(PardinusBounds pb, Instance instance) {
+        int counter = 0;
+        for(Relation r : pb.targets().keySet()) {
+            for(Tuple t : pb.target(r)) {
+                if(!instance.tuples(r).contains(t))
+                    counter++;
+            }
+            for(Tuple t : instance.tuples(r)) {
+                if(!pb.target(r).contains(t))
+                    counter++;
+            }
+        }
+        return counter;
+    }
+}

--- a/src/main/java/kodkod/examples/pardinus/target/NoRetargeting.java
+++ b/src/main/java/kodkod/examples/pardinus/target/NoRetargeting.java
@@ -76,7 +76,7 @@ public class NoRetargeting {
         eo.setBitwidth(1); // minimal bitwidth allowed
         eo.setRetargeter(new Retargeter() {
             @Override
-            public void retarget(ExtendedOptions opts, Translation transl) {
+            public void retarget(Translation transl) {
                 // Do nothing; keep initial target
             }
         });

--- a/src/main/java/kodkod/examples/pardinus/target/NoRetargeting.java
+++ b/src/main/java/kodkod/examples/pardinus/target/NoRetargeting.java
@@ -76,7 +76,7 @@ public class NoRetargeting {
         eo.setBitwidth(1); // minimal bitwidth allowed
         eo.setRetargeter(new Retargeter() {
             @Override
-            public void retarget(TargetSATSolver tcnf, ExtendedOptions opts, Translation transl) {
+            public void retarget(ExtendedOptions opts, Translation transl) {
                 // Do nothing; keep initial target
             }
         });

--- a/src/main/java/kodkod/examples/pardinus/target/NoRetargeting.java
+++ b/src/main/java/kodkod/examples/pardinus/target/NoRetargeting.java
@@ -65,7 +65,7 @@ public class NoRetargeting {
         eo.setBitwidth(1); // minimal
         eo.setRetargeter(new Retargeter() {
             @Override
-            public void retarget(TargetSATSolver tcnf, TargetOptions.TMode mode, Translation transl, int primaryVars) {
+            public void retarget(TargetSATSolver tcnf, ExtendedOptions opts, Translation transl) {
                 // Do nothing; keep initial target
             }
         });
@@ -75,15 +75,16 @@ public class NoRetargeting {
         // instance as close as possible to the initial target.
         // So instead, flip the goal. Target-mode doesn't matter here
         // since it's all about retargeting and we're providing a retargeter.
-        eo.setTargetMode(TargetOptions.TMode.CLOSE);
+        //eo.setTargetMode(TargetOptions.TMode.CLOSE);
 
+        // Don't do this if you want close
         // Flip initial target
         PardinusBounds origpb = pb.clone();
-        for(Relation rel : pb.targets().keySet()) {
+        /*for(Relation rel : pb.targets().keySet()) {
             TupleSet tuples = u.factory().allOf(rel.arity());
             tuples.removeAll(pb.targets().get(rel));
             pb.setTarget(rel, tuples);
-        }
+        }*/
         System.out.println("flipped target for p: "+pb.target(p));
         System.out.println("flipped target for q: "+pb.target(q));
         System.out.println("flipped target for r: "+pb.target(r));


### PR DESCRIPTION
This PR adds the Retargeter interface, which can be implemented and an instance provided to ExtendedOptions. If given, ExtendedSolver will use the strategy for retargeting (rather than the default, target-latest-instance). Instance-exclusion clause will be issued for each instance seen regardless of retargeting strategy. 

The NoRetargeting.java example demos how to use a Retargeter to keep the target constant. 

Note that there is some abstraction leak here: Retargeter exposes the underlying solver interface for maximal flexibility to the caller. This was done on purpose to enable research code without forking + modifying the underlying Pardinus classes.

I've added the retargeter option to both ExtendedOptions and TargetOptions, because I was unsure if TargetOptions needed it. The example uses ExtendedOptions.

Happy to discuss or modify these changes as needed.